### PR TITLE
Implement dependency selectors

### DIFF
--- a/examples/selectors/consoleMessagePrinter.js
+++ b/examples/selectors/consoleMessagePrinter.js
@@ -1,0 +1,19 @@
+/*!
+ * circuitbox
+ * Copyright (c) 2014-2015 Ranganath Kini <codematix@codematix.me>
+ * Copyright (c) 2015 intuitivcloud Engineering <engineering@intuitivcloud.com>
+ * MIT Licensed
+ */
+
+'use strict';
+
+// Our console message printer
+function ConsoleMessagePrinter() {
+  return {
+    print: function (message) {
+      console.log(message);
+    }
+  };
+}
+
+module.exports = ConsoleMessagePrinter;

--- a/examples/selectors/selectors.js
+++ b/examples/selectors/selectors.js
@@ -1,0 +1,58 @@
+'use strict';
+
+// require circuitbox
+var _ = require('lodash'),
+    circuitbox = require('../../lib');
+
+// create a circuitbox
+circuitbox.create({
+  modules: [
+    function (registry) {
+      // define the message printer - does a module.require internally
+      registry.for('messagePrinter').requires('./consoleMessagePrinter')
+        .dependsOn('messageSource');
+
+      registry.for('helloCommand').use(function (deps) {
+        return function (p) {
+          deps.messagePrinter.print('Hello ' + p.name + '!');
+        };
+      }).dependsOn('messagePrinter');
+
+      registry.for('goodbyeCommand').use(function (deps) {
+        return function (p) {
+          deps.messagePrinter.print('Goodbye ' + p.name + '!');
+        };
+      }).dependsOn('messagePrinter');
+
+      registry.for('locationCommand').use(function (deps) {
+        return function (p) {
+          deps.messagePrinter.print('I live in ' + p.city + '!');
+        };
+      }).dependsOn('messagePrinter');
+
+      registry.for('peopleManager').use(function (deps) {
+        return function (p) {
+          _.each(deps.commands, function (cmd) {
+            cmd.call(null, p);
+          });
+        };
+      }).dependsOn('commands:name:*Command');
+
+    }
+  ]
+}).then(function (cbx) {
+
+  // get the message printer and print a message
+  cbx.get('peopleManager').then(function (pm) {
+    pm({
+      name: 'John Doe',
+      city: 'Timbuctoo'
+    });
+  }, function (err) {
+    console.log('Could not recieve a people manager', err);
+    return;
+  });
+
+}, function (err) {
+  console.log('Could not create circuitbox', err);
+});

--- a/examples/selectors/selectors.js
+++ b/examples/selectors/selectors.js
@@ -1,3 +1,10 @@
+/*!
+ * circuitbox
+ * Copyright (c) 2014-2015 Ranganath Kini <codematix@codematix.me>
+ * Copyright (c) 2015 intuitivcloud Engineering <engineering@intuitivcloud.com>
+ * MIT Licensed
+ */
+
 'use strict';
 
 // require circuitbox
@@ -9,8 +16,7 @@ circuitbox.create({
   modules: [
     function (registry) {
       // define the message printer - does a module.require internally
-      registry.for('messagePrinter').requires('./consoleMessagePrinter')
-        .dependsOn('messageSource');
+      registry.for('messagePrinter').requires('./consoleMessagePrinter');
 
       registry.for('helloCommand').use(function (deps) {
         return function (p) {

--- a/lib/assembler.js
+++ b/lib/assembler.js
@@ -1,0 +1,86 @@
+'use strict';
+
+var _ = require('lodash'),
+    async = require('async'),
+    SelectorFactory = require('./selectorFactory');
+
+// returns a function which builds an Assembler for the specified component name
+function singleComponentAssembler(cName) {
+  /* jshint validthis: true */
+  var t = this;
+
+  return function (aCb) {
+    var r = t._reg,
+        d;
+
+    try {
+      d = r.find(cName);
+
+      // have the scope handler resolve the component
+      return t._scopeFactory.handlerFor(d.scope).resolve(d, function (err, cmp) {
+        var r;
+
+        if (err) return aCb(err);
+
+        // return an object with key as component name and value as component
+        r = {};
+        r[cName] = cmp;
+
+        return aCb(null, r);
+      });
+    } catch (e) {
+      return aCb(e);
+    }
+
+  };
+}
+
+/*
+ * Returns a function which when called, assembles an object
+ * that holds the multiple components defined by selector expression
+ */
+function multiComponentAssembler(expr) {
+  /* jshint validthis: true */
+  var t = this;
+
+  /* jshint unused: false */
+  return function (aCb) {
+    var r = t._reg,
+        selExpr, defs, asmrs;
+
+    try {
+      selExpr = SelectorFactory.parse(expr);
+      defs = r.findBySelector(SelectorFactory.selectorFor(selExpr));
+
+      asmrs = _.map(defs, function (def) {
+        return singleComponentAssembler.call(t, def.name);
+      });
+
+      async.series(asmrs, function (err, cmps) {
+        var cmp;
+
+        if (err) return aCb(err);
+
+        cmp = {};
+        cmp[selExpr.name] = _.chain(cmps).reduce(_.extend, {}).value();
+
+        return aCb(null, cmp);
+      });
+    } catch (e) {
+      return aCb(e);
+    }
+  };
+}
+
+function assembler(cName) {
+  /*jshint validthis: true*/
+  var asmrFn;
+
+  // if component name is a selector expression, use multi-component assembly
+  asmrFn = (SelectorFactory.hasSelector(cName)) ?
+    multiComponentAssembler : singleComponentAssembler;
+
+  return asmrFn.call(this, cName);
+}
+
+module.exports = assembler;

--- a/lib/binder.js
+++ b/lib/binder.js
@@ -10,10 +10,12 @@
 var _ = require('lodash'),
     ComponentDefinitionBuilderFactory = require('./componentDefinitionBuilderFactory'),
     ComponentCreatorFactory = require('./componentCreatorFactory'),
-    ScopeHandlerFactory = require('./scopeHandlerFactory');
+    ScopeHandlerFactory = require('./scopeHandlerFactory'),
+    SelectorFactory = require('./selectorFactory');
 
 _.extend(exports, {
   registerDefinitionBuilder: ComponentDefinitionBuilderFactory.registerBuilder,
   registerComponentCreator: ComponentCreatorFactory.registerCreator,
-  registerScopeHandler: ScopeHandlerFactory.registerScopeHandler
+  registerScopeHandler: ScopeHandlerFactory.registerScopeHandler,
+  registerSelector: SelectorFactory.registerSelector
 });

--- a/lib/componentDefinition.js
+++ b/lib/componentDefinition.js
@@ -21,6 +21,7 @@ function ComponentDefinition(name) {
 
   _.extend(this, {
     name: name,
+    type: 'core.base',
     scope: 'singleton',
     dependencies: []
   }, _.pick(opts, 'initializer', 'scope', 'dependencies'));

--- a/lib/componentFactory.js
+++ b/lib/componentFactory.js
@@ -11,28 +11,8 @@ var _ = require('lodash'),
     async = require('async'),
     ComponentDefinition = require('./componentDefinition'),
     ComponentCreatorFactory = require('./componentCreatorFactory'),
-    ScopeHandlerFactory = require('./scopeHandlerFactory');
-
-// returns a function which builds an Assembler for the specified component name
-function assembler(cName) {
-  /*jshint validthis: true*/
-  var t = this;
-
-  return function (aCb) {
-    var r = t._reg,
-        d;
-
-    try {
-      d = r.find(cName);
-
-      // have the scope handler resolve the component
-      return t._scopeFactory.handlerFor(d.scope).resolve(d, aCb);
-    } catch (e) {
-      return aCb(e);
-    }
-
-  };
-}
+    ScopeHandlerFactory = require('./scopeHandlerFactory'),
+    assembler = require('./assembler');
 
 function ComponentFactory(registry) {
   this._cfactory = new ComponentCreatorFactory();
@@ -60,7 +40,7 @@ ComponentFactory.prototype.create = function (tgt, cb) {
     if (err) return cb(err);
 
     // put together the component definitions with their names
-    deps = _.object(depNames, cmps);
+    deps = _.chain(cmps).reduce(_.extend, {}).value();
 
     // inject process.env
     deps.env = process.env;
@@ -74,6 +54,5 @@ ComponentFactory.prototype.create = function (tgt, cb) {
     }
   });
 };
-
 
 module.exports = ComponentFactory;

--- a/lib/defaultBindings.js
+++ b/lib/defaultBindings.js
@@ -7,7 +7,8 @@
 
 'use strict';
 
-var r = require;
+var r = require,
+    _ = r('lodash');
 
 module.exports = function (binder) {
   binder.registerDefinitionBuilder('use', r('./simpleComponentDefinitionBuilder'));
@@ -18,4 +19,9 @@ module.exports = function (binder) {
 
   binder.registerScopeHandler('singleton', r('./singletonScopeHandler'));
   binder.registerScopeHandler('prototype', r('./prototypeScopeHandler'));
+
+  // register the default selectors
+  _.each(r('./defaultSelectors'), function (selectorFn, selectorName) {
+    binder.registerSelector(selectorName, selectorFn);
+  });
 };

--- a/lib/defaultSelectors.js
+++ b/lib/defaultSelectors.js
@@ -13,7 +13,7 @@ exports.regexp = function (pattern, cd) {
   // small optimization to improve performance
   // avoids repeated regex compilation
   if (!rex)
-    rex = rexCache[pattern] = RegExp(pattern);
+    rex = rexCache[pattern] = new RegExp(pattern);
 
   return rex.test(cd.name);
 };

--- a/lib/defaultSelectors.js
+++ b/lib/defaultSelectors.js
@@ -1,3 +1,10 @@
+/*!
+ * circuitbox
+ * Copyright (c) 2014-2015 Ranganath Kini <codematix@codematix.me>
+ * Copyright (c) 2015 intuitivcloud Engineering <engineering@intuitivcloud.com>
+ * MIT Licensed
+ */
+
 'use strict';
 
 var minimatch = require('minimatch'),

--- a/lib/defaultSelectors.js
+++ b/lib/defaultSelectors.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var minimatch = require('minimatch'),
+    rexCache = {};
+
+exports.type = function (pattern, cd) {
+  return cd.type === pattern;
+};
+
+exports.regexp = function (pattern, cd) {
+  var rex = rexCache[pattern];
+
+  // small optimization to improve performance
+  // avoids repeated regex compilation
+  if (!rex)
+    rex = rexCache[pattern] = RegExp(pattern);
+
+  return rex.test(cd.name);
+};
+
+exports.name = function (pattern, cd) {
+  return minimatch(cd.name, pattern);
+};

--- a/lib/moduleComponentDefinition.js
+++ b/lib/moduleComponentDefinition.js
@@ -22,7 +22,10 @@ function ModuleComponentDefinition(name, moduleId) {
 
   moduleId = normalizeModulePath(moduleId);
 
-  _.extend(this, { moduleId: moduleId });
+  _.extend(this, {
+    type: 'core.module',
+    moduleId: moduleId
+  });
 }
 
 inherits(ModuleComponentDefinition, Component);

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -39,6 +39,10 @@ _.extend(Registry.prototype, {
     return def;
   },
 
+  findBySelector: function (selectorFn) {
+    return _.chain(this._defs).values().select(selectorFn).value();
+  },
+
   registerModule: function (module) {
     // indirection to protect this ComponentRegistry instance
     var cList = [];

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -40,14 +40,17 @@ _.extend(Registry.prototype, {
   },
 
   findBySelector: function (selectorFn) {
-    return _.chain(this._defs).values().select(selectorFn).value();
+    var r = _.chain(this._defs).values().select(selectorFn).value();
+    if (_.isEmpty(r)) throw new Error('No definitions found matching selector');
+    return r;
   },
 
   registerModule: function (module) {
     // indirection to protect this ComponentRegistry instance
     var cList = [];
 
-    if (!(_.isFunction(module) || _.isString(module))) throw new Error('a module must be a function or a module-id string');
+    if (!(_.isFunction(module) || _.isString(module)))
+      throw new Error('a module must be a function or a module-id string');
 
     // if the module specified is not a function, its most likely a module-id to be loaded
     module = _.isFunction(module) ? module : require(normalizeModulePath(module));

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -40,9 +40,7 @@ _.extend(Registry.prototype, {
   },
 
   findBySelector: function (selectorFn) {
-    var r = _.chain(this._defs).values().select(selectorFn).value();
-    if (_.isEmpty(r)) throw new Error('No definitions found matching selector');
-    return r;
+    return _.chain(this._defs).values().select(selectorFn).value();
   },
 
   registerModule: function (module) {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -11,7 +11,8 @@ var _ = require('lodash'),
     utils = require('./utils'),
     fmt = utils.fmt,
     normalizeModulePath = utils.normalizeModulePath,
-    ComponentDefinitionBuilderFactory = require('./componentDefinitionBuilderFactory');
+    ComponentDefinitionBuilderFactory = require('./componentDefinitionBuilderFactory'),
+    SelectorFactory = require('./selectorFactory');
 
 function buildDefinitions(lst) {
   /*jshint validthis: true */
@@ -72,9 +73,13 @@ _.extend(Registry.prototype, {
   dependencyListFor: function (name) {
     // start with the definition of target component
     var t = this,
-        d = t.find(name),
-        r = [ d.name ], // put that in our list
-        deps = (d.dependencies || []);
+        d, r, deps;
+
+    if (SelectorFactory.hasSelector(name)) return [ name ];
+
+    d = t.find(name);
+    r = [ d.name ];                   // put that in our list
+    deps = (d.dependencies || []);
 
     // for each dependency of the target component
     // trigger a recursive search for all deps

--- a/lib/selectorFactory.js
+++ b/lib/selectorFactory.js
@@ -30,6 +30,11 @@ _.extend(exports, {
     return selectorRex.test(expr);
   },
 
+  extractSelectorName: function (expr) {
+    if (!this.hasSelector(expr)) return expr;
+    return this.parse(expr).name;
+  },
+
   selectorFor: function (expr) {
     var sel = this.parse(expr);
 

--- a/lib/selectorFactory.js
+++ b/lib/selectorFactory.js
@@ -1,0 +1,53 @@
+/*!
+ * circuitbox
+ * Copyright (c) 2014-2015 Ranganath Kini <codematix@codematix.me>
+ * Copyright (c) 2015 intuitivcloud Systems <engineering@intuitivcloud.com>
+ * MIT Licensed
+ */
+
+'use strict';
+
+var _ = require('lodash'),
+    fmt = require('./utils').fmt,
+    selectorRex = /([a-zA-Z0-9]*)\:([a-zA-Z]*)\:(.*)$/,
+    sMap = {};
+
+_.extend(exports, {
+
+  registerSelector: function (name, selectorFn) {
+    if (sMap[name]) throw new Error(fmt('Selector already registered with name "%s"', name));
+    if (selectorFn.length !== 2) throw new Error(
+      'Specified selector function does not accept 2 parameters, "pattern" and "componentDefinition"');
+
+    sMap[name] = selectorFn;
+  },
+
+  reset: function () {
+    sMap = {};
+  },
+
+  hasSelector: function (expr) {
+    return selectorRex.test(expr);
+  },
+
+  selectorFor: function (expr) {
+    var sel = this.parse(expr);
+
+    if (!(sel.selector in sMap)) throw new Error(fmt('No selector registered with name "%s"', sel.selector));
+    return _.partial(sMap[sel.selector], sel.pattern);
+  },
+
+  parse: function (expr) {
+    var matches;
+    
+    if (!this.hasSelector(expr)) throw new Error(fmt('Expression "%s" is not a valid selector expression', expr));
+    matches = selectorRex.exec(expr).slice(1);
+
+    return {
+      name: matches[0],
+      selector: matches[1],
+      pattern: matches[2]
+    };
+  }
+  
+});

--- a/lib/selectorFactory.js
+++ b/lib/selectorFactory.js
@@ -30,11 +30,6 @@ _.extend(exports, {
     return selectorRex.test(expr);
   },
 
-  extractSelectorName: function (expr) {
-    if (!this.hasSelector(expr)) return expr;
-    return this.parse(expr).name;
-  },
-
   selectorFor: function (expr) {
     var sel = this.parse(expr);
 

--- a/lib/selectorFactory.js
+++ b/lib/selectorFactory.js
@@ -22,7 +22,7 @@ _.extend(exports, {
     sMap[name] = selectorFn;
   },
 
-  reset: function () {
+  _reset: function () {
     sMap = {};
   },
 
@@ -31,7 +31,9 @@ _.extend(exports, {
   },
 
   selectorFor: function (expr) {
-    var sel = this.parse(expr);
+    var sel = _.isString(expr) ? this.parse(expr) : expr;
+
+    if (!(sel.name && sel.selector && sel.pattern)) throw Error('Not a valid selector expression object');
 
     if (!(sel.selector in sMap)) throw new Error(fmt('No selector registered with name "%s"', sel.selector));
     return _.partial(sMap[sel.selector], sel.pattern);

--- a/lib/simpleComponentDefinition.js
+++ b/lib/simpleComponentDefinition.js
@@ -18,7 +18,10 @@ function SimpleComponentDefinition(name, value) {
 
   Component.call(this, name, options);
 
-  _.extend(this, { value: value });
+  _.extend(this, {
+    type: 'core.simple',
+    value: value
+  });
 }
 
 inherits(SimpleComponentDefinition, Component);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "lodash": "^3.7.0",
+    "minimatch": "^2.0.4",
     "q": "^1.2.0"
   },
   "devDependencies": {

--- a/test/binder.test.js
+++ b/test/binder.test.js
@@ -11,6 +11,7 @@ var expect = require('chai').expect,
     ComponentDefinitionBuilderFactory = require('../lib/componentDefinitionBuilderFactory'),
     ComponentCreatorFactory = require('../lib/componentCreatorFactory'),
     ScopeHandlerFactory = require('../lib/scopeHandlerFactory'),
+    SelectorFactory = require('../lib/selectorFactory'),
     Binder = require('../lib/binder');
 
 describe('Binder', function () {
@@ -25,6 +26,10 @@ describe('Binder', function () {
 
   it('should expose the #registerScopeHandler method of ScopeHandlerFactory to the bindings', function () {
     expect(Binder.registerScopeHandler).to.be.equal(ScopeHandlerFactory.registerScopeHandler);
+  });
+
+  it('should expose the #registerSelector method of SelectorFactory to the bindings', function () {
+    expect(Binder.registerSelector).to.be.equal(SelectorFactory.registerSelector);
   });
 
 });

--- a/test/circuitbox.test.js
+++ b/test/circuitbox.test.js
@@ -13,7 +13,8 @@ var _ = require('lodash'),
     circuitbox = require('../lib'),
     ComponentDefinitionBuilderFactory = require('../lib/componentDefinitionBuilderFactory'),
     ComponentCreatorFactory = require('../lib/componentCreatorFactory'),
-    ScopeHandlerFactory = require('../lib/scopeHandlerFactory');
+    ScopeHandlerFactory = require('../lib/scopeHandlerFactory'),
+    SelectorFactory = require('../lib/selectorFactory');
 
 describe('circuitbox', function () {
   /*jshint expr: true*/
@@ -22,7 +23,8 @@ describe('circuitbox', function () {
     _.each([
       ComponentDefinitionBuilderFactory,
       ComponentCreatorFactory,
-      ScopeHandlerFactory
+      ScopeHandlerFactory,
+      SelectorFactory
     ], function (f) {
       f._reset();
     });

--- a/test/componentDefinition.test.js
+++ b/test/componentDefinition.test.js
@@ -28,6 +28,13 @@ describe('ComponentDefinition', function () {
     expect(c.name).to.be.equal(n);
   });
 
+  it('should have type as core.base', function () {
+    var n = 'myComponent',
+        c = new ComponentDefinition(n);
+
+    expect(c.type).to.be.equal('core.base');
+  });
+
   it('should be created with a singleton scope by default if no scope is specified', function () {
     var c = new ComponentDefinition('myComponent');
 

--- a/test/defaultBindings.test.js
+++ b/test/defaultBindings.test.js
@@ -10,18 +10,25 @@
 var r = require,
     sinon = r('sinon'),
     DefaultBindings = r('../lib/defaultBindings'),
+    SelectorFactory = r('../lib/selectorFactory'),
     binderApi = {
       registerDefinitionBuilder: function () {},
       registerComponentCreator: function () {},
-      registerScopeHandler: function () {}
+      registerScopeHandler: function () {},
+      registerSelector: function () {}
     };
 
 describe('DefaultBindings', function () {
   /*jshint expr: true*/
 
+  afterEach(function () {
+    SelectorFactory._reset();
+  });
+
   it('should register the default ComponentDefinitionBuilders, ComponentCreators and ScopeHandlers', function () {
     /*jshint newcap: false*/
-    var mB = sinon.mock(binderApi);
+    var mB = sinon.mock(binderApi),
+        defaultSelectors = r('../lib/defaultSelectors');
 
     mB.expects('registerDefinitionBuilder').withArgs('use', r('../lib/simpleComponentDefinitionBuilder')).once();
     mB.expects('registerDefinitionBuilder').withArgs('requires', r('../lib/moduleComponentDefinitionBuilder')).once();
@@ -31,6 +38,10 @@ describe('DefaultBindings', function () {
 
     mB.expects('registerScopeHandler').withArgs('singleton', r('../lib/singletonScopeHandler')).once();
     mB.expects('registerScopeHandler').withArgs('prototype', r('../lib/prototypeScopeHandler')).once();
+
+    mB.expects('registerSelector').withArgs('type', defaultSelectors.type).once();
+    mB.expects('registerSelector').withArgs('regexp', defaultSelectors.regexp).once();
+    mB.expects('registerSelector').withArgs('name', defaultSelectors.name).once();
 
     DefaultBindings(binderApi);
 

--- a/test/defaultSelectors.test.js
+++ b/test/defaultSelectors.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+var _ = require('lodash'),
+    expect = require('chai').expect,
+    SimpleComponentDefinition = require('../lib/simpleComponentDefinition'),
+    ModuleComponentDefinition = require('../lib/moduleComponentDefinition'),
+    defaultSelectors = require('../lib/defaultSelectors');
+
+describe('Default Selectors', function () {
+  var components = [
+    new SimpleComponentDefinition('a', 'Foo'),
+    new SimpleComponentDefinition('b', 'Bar'),
+
+    new SimpleComponentDefinition('evenNumber', 2),
+    new SimpleComponentDefinition('oddNumber', 1),
+
+    new SimpleComponentDefinition('GET /foo/bar', 'Get Foo-Bar'),
+    new SimpleComponentDefinition('POST /foo/bar', 'Post Foo-Bar'),
+
+    new ModuleComponentDefinition('express', './foo'),
+    new ModuleComponentDefinition('nimrod', './nimrod')
+  ];
+
+  describe('Type Selector', function () {
+    var sel = defaultSelectors.type;
+
+    it('should return all component definitions of type core.simple', function () {
+      var simpleSel = _.partial(sel, 'core.simple'),
+          defs = _.filter(components, simpleSel);
+
+      expect(defs).to.have.lengthOf(6);
+    });
+
+    it('should return all component definitions of type core.module', function () {
+      var moduleSel = _.partial(sel, 'core.module'),
+          defs = _.filter(components, moduleSel);
+
+      expect(defs).to.have.lengthOf(2);
+    });
+
+    it('should return empty list when matching component definitions of unknown type', function () {
+      /* jshint expr: true */
+      var unknownSel = _.partial(sel, 'core.foo'),
+          defs = _.filter(components, unknownSel);
+
+      expect(defs).to.be.empty;
+    });
+
+  });
+
+  describe('RegExp Selector', function () {
+    var sel = defaultSelectors.regexp;
+
+    it('should return all component definitions whose name ends with Number', function () {
+      var simpleSel = _.partial(sel, '.*Number$'),
+          defs = _.filter(components, simpleSel);
+
+      expect(defs).to.have.lengthOf(2);
+      expect(defs[0].name).to.be.eql('evenNumber');
+      expect(defs[1].name).to.be.eql('oddNumber');
+    });
+
+    it('should return all component definitions whose name has a single character', function () {
+      var simpleSel = _.partial(sel, '^[a-z]$'),
+          defs = _.filter(components, simpleSel);
+
+      expect(defs).to.have.lengthOf(2);
+      expect(defs[0].name).to.be.eql('a');
+      expect(defs[1].name).to.be.eql('b');
+    });
+
+    it('should return all component definitions whose name matches the regular expression', function () {
+      var simpleSel = _.partial(sel, '^[GET|POST].*$'),
+          defs = _.filter(components, simpleSel);
+
+      expect(defs).to.have.lengthOf(2);
+      expect(defs[0].name).to.be.eql('GET /foo/bar');
+      expect(defs[1].name).to.be.eql('POST /foo/bar');
+    });
+
+    it('should return empty list when no matching components were found', function () {
+      /* jshint expr: true */
+      var unknownSel = _.partial(sel, '2'),
+          defs = _.filter(components, unknownSel);
+
+      expect(defs).to.be.empty;
+    });
+
+  });
+
+  describe('Name Selector', function () {
+    var sel = defaultSelectors.name;
+
+    it('should return all component definitions whose name ends with Number', function () {
+      var simpleSel = _.partial(sel, '*Number'),
+          defs = _.filter(components, simpleSel);
+
+      expect(defs).to.have.lengthOf(2);
+      expect(defs[0].name).to.be.eql('evenNumber');
+      expect(defs[1].name).to.be.eql('oddNumber');
+    });
+
+    it('should return empty list when no matching components were found', function () {
+      /* jshint expr: true */
+      var unknownSel = _.partial(sel, '*Foo'),
+          defs = _.filter(components, unknownSel);
+
+      expect(defs).to.be.empty;
+    });
+
+  });
+
+});

--- a/test/defaultSelectors.test.js
+++ b/test/defaultSelectors.test.js
@@ -6,20 +6,24 @@ var _ = require('lodash'),
     ModuleComponentDefinition = require('../lib/moduleComponentDefinition'),
     defaultSelectors = require('../lib/defaultSelectors');
 
-describe('Default Selectors', function () {
-  var components = [
-    new SimpleComponentDefinition('a', 'Foo'),
-    new SimpleComponentDefinition('b', 'Bar'),
+describe.only('Default Selectors', function () {
+  var components;
 
-    new SimpleComponentDefinition('evenNumber', 2),
-    new SimpleComponentDefinition('oddNumber', 1),
+  before(function () {
+    components = [
+      new SimpleComponentDefinition('a', 'Foo'),
+      new SimpleComponentDefinition('b', 'Bar'),
 
-    new SimpleComponentDefinition('GET /foo/bar', 'Get Foo-Bar'),
-    new SimpleComponentDefinition('POST /foo/bar', 'Post Foo-Bar'),
+      new SimpleComponentDefinition('evenNumber', 2),
+      new SimpleComponentDefinition('oddNumber', 1),
 
-    new ModuleComponentDefinition('express', './foo'),
-    new ModuleComponentDefinition('nimrod', './nimrod')
-  ];
+      new SimpleComponentDefinition('GET /foo/bar', 'Get Foo-Bar'),
+      new SimpleComponentDefinition('POST /foo/bar', 'Post Foo-Bar'),
+
+      new ModuleComponentDefinition('express', 'foo'),
+      new ModuleComponentDefinition('nimrod', 'nimrod')
+    ];
+  });
 
   describe('Type Selector', function () {
     var sel = defaultSelectors.type;

--- a/test/defaultSelectors.test.js
+++ b/test/defaultSelectors.test.js
@@ -1,3 +1,10 @@
+/*!
+ * circuitbox
+ * Copyright (c) 2014-2015 Ranganath Kini <codematix@codematix.me>
+ * Copyright (c) 2015 intuitivcloud Engineering <engineering@intuitivcloud.com>
+ * MIT Licensed
+ */
+
 'use strict';
 
 var _ = require('lodash'),

--- a/test/defaultSelectors.test.js
+++ b/test/defaultSelectors.test.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
     ModuleComponentDefinition = require('../lib/moduleComponentDefinition'),
     defaultSelectors = require('../lib/defaultSelectors');
 
-describe.only('Default Selectors', function () {
+describe('Default Selectors', function () {
   var components;
 
   before(function () {

--- a/test/moduleComponentDefinition.test.js
+++ b/test/moduleComponentDefinition.test.js
@@ -43,6 +43,13 @@ describe('ModuleComponentDefinition', function () {
 
   });
 
+  it('should have type as core.module', function () {
+    var c = new ModuleComponentDefinition('myComponent', 'foo');
+
+    expect(c.type).to.be.equal('core.module');
+
+  });
+
   it('should return the module-id normalized to global base path', function () {
     expect(new ModuleComponentDefinition('myComponent', './foo').moduleId).to.be.equal(path.join(__dirname, './foo'));
   });

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -135,6 +135,8 @@ describe('Registry', function () {
 
       r.registerModule(function (reg) {
         reg.for('myComponent').use('This is myComponent');
+        reg.for('luckyNumber').use(10);
+        reg.for('unluckyNumber').use(20);
       });
 
     });
@@ -154,6 +156,16 @@ describe('Registry', function () {
       expect(function () {
         r.find('unregisteredComponent');
       }).to.throw('No definition found for component \'unregisteredComponent\'');
+    });
+
+    it('should retrieve a list of definitions that match the specified selector', function () {
+      var numbers = r.findBySelector(function (def) {
+        return typeof def.value === 'number';
+      });
+
+      expect(numbers).to.have.lengthOf(2);
+      expect(numbers[0].name).to.be.eql('luckyNumber');
+      expect(numbers[1].name).to.be.eql('unluckyNumber');
     });
 
   });

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -168,6 +168,12 @@ describe('Registry', function () {
       expect(numbers[1].name).to.be.eql('unluckyNumber');
     });
 
+    it('should throw error if no component definitions matched the specified selector', function () {
+      expect(function () {
+        r.findBySelector(function () { return false; });
+      }).to.throw('No definitions found matching selector');
+    });
+
   });
 
 });

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -168,10 +168,11 @@ describe('Registry', function () {
       expect(numbers[1].name).to.be.eql('unluckyNumber');
     });
 
-    it('should throw error if no component definitions matched the specified selector', function () {
-      expect(function () {
-        r.findBySelector(function () { return false; });
-      }).to.throw('No definitions found matching selector');
+    it('should return empty array if no component definitions matched the specified selector', function () {
+      var deps = r.findBySelector(function () { return false; });
+
+      expect(deps).to.be.an.array;
+      expect(deps).to.be.empty;
     });
 
   });

--- a/test/selectorFactory.test.js
+++ b/test/selectorFactory.test.js
@@ -35,6 +35,20 @@ describe('SelectorFactory', function () {
     }).to.throw('Expression "a:" is not a valid selector expression');
   });
 
+  it('should extract and return the name from the specified selector expression', function () {
+    expect(SelectorFactory.extractSelectorName('a:b:c')).to.be.eql('a');
+  });
+
+  it('should return expression as-is when extracting name if it is not a valid selector expression', function () {
+    expect(SelectorFactory.extractSelectorName('a')).to.be.eql('a');
+  });
+
+  it('should throw error if attempt made to parse an invalid selector expression', function () {
+    expect(function () {
+      SelectorFactory.parse('a:');
+    }).to.throw('Expression "a:" is not a valid selector expression');
+  });
+
   context('registering selectors', function () {
 
     afterEach(function () {

--- a/test/selectorFactory.test.js
+++ b/test/selectorFactory.test.js
@@ -1,0 +1,104 @@
+/*!
+ * circuitbox
+ * Copyright (c) 2014-2015 Ranganath Kini <codematix@codematix.me>
+ * Copyright (c) 2015 intuitivcloud Systems <engineering@intuitivcloud.com>
+ * MIT Licensed
+ */
+
+'use strict';
+
+var context = describe,
+    expect = require('chai').expect,
+    SelectorFactory = require('../lib/selectorFactory');
+
+describe('SelectorFactory', function () {
+
+  it('should detect if an expression contains a selector', function () {
+    expect(SelectorFactory.hasSelector('a:b:c')).to.be.equal(true);
+  });
+
+  it('should detect if an expression does not contain a selector', function () {
+    expect(SelectorFactory.hasSelector('a:')).to.be.equal(false);
+  });
+
+  it('should parse a selector expression and extract name, selector and pattern', function () {
+    expect(SelectorFactory.parse('a:b:c')).to.be.eql({
+      name: 'a',
+      selector: 'b',
+      pattern: 'c'
+    });
+  });
+
+  it('should throw error if attempt made to parse an invalid selector expression', function () {
+    expect(function () {
+      SelectorFactory.parse('a:');
+    }).to.throw('Expression "a:" is not a valid selector expression');
+  });
+
+  context('registering selectors', function () {
+
+    afterEach(function () {
+      SelectorFactory.reset();
+    });
+
+    it('should register a specified selector function with the specified name', function () {
+      var selectorName = 'b',
+          selectorFn = function (pat, cd) { /* jshint unused: false */ };
+
+      expect(function () {
+        SelectorFactory.registerSelector(selectorName, selectorFn);
+      }).not.to.throw();
+      
+    });
+    
+    it('should throw error if a selector with specified name is already registered', function () {
+      var selectorName = 'b',
+          selectorFn = function (pat, cd) { /* jshint unused: false */ };
+      
+      SelectorFactory.registerSelector(selectorName, selectorFn);
+      
+      expect(function () {
+        SelectorFactory.registerSelector(selectorName, selectorFn);
+      }).to.throw('Selector already registered with name "b"');
+      
+    });
+
+    it('should throw error if a selector function does not accept 2 parameters', function () {
+      var selectorName = 'b',
+          selectorFn = function () {};
+      
+      expect(function () {
+        SelectorFactory.registerSelector(selectorName, selectorFn);
+      }).to.throw('Specified selector function does not accept 2 parameters, "pattern" and "componentDefinition"');
+      
+    });
+
+    it('should parse and return selector for specified expression which takes componentDefinition as parameter', function () {
+      var selectorExpr = 'values:foo:1-10',
+          dummyComponentDefinition = { name: 'watchamacallit' },
+          selector;
+
+      SelectorFactory.registerSelector('foo', function (pat, cd) {
+        expect(pat).to.be.equal('1-10');
+        expect(cd).to.be.equal(dummyComponentDefinition);
+      });
+
+      // get the selector for an expression
+      selector = SelectorFactory.selectorFor(selectorExpr);
+
+      expect(selector).to.be.a('function');
+      
+      // invoke the selector with a dummy component definition
+      selector(dummyComponentDefinition);
+      
+    });
+
+    it('should throw error if no selectors are registered for the specified selector expression', function () {
+      expect(function () {
+        SelectorFactory.selectorFor('values:foo:1-10');
+      }).to.throw('No selector registered with name "foo"');
+    });
+    
+  });
+  
+});

--- a/test/selectorFactory.test.js
+++ b/test/selectorFactory.test.js
@@ -44,7 +44,7 @@ describe('SelectorFactory', function () {
   context('registering selectors', function () {
 
     afterEach(function () {
-      SelectorFactory.reset();
+      SelectorFactory._reset();
     });
 
     it('should register a specified selector function with the specified name', function () {
@@ -99,9 +99,49 @@ describe('SelectorFactory', function () {
       
     });
 
+    it('should return selector for specified expression object which takes componentDefinition as parameter', function () {
+      var selectorExpr = {
+            name: 'values',
+            selector: 'foo',
+            pattern: '1-10'
+          },
+          dummyComponentDefinition = { name: 'watchamacallit' },
+          selector;
+
+      SelectorFactory.registerSelector('foo', function (pat, cd) {
+        expect(pat).to.be.equal('1-10');
+        expect(cd).to.be.equal(dummyComponentDefinition);
+      });
+
+      // get the selector for an expression
+      selector = SelectorFactory.selectorFor(selectorExpr);
+
+      expect(selector).to.be.a('function');
+
+      // invoke the selector with a dummy component definition
+      selector(dummyComponentDefinition);
+
+    });
+
     it('should throw error if no selectors are registered for the specified selector expression', function () {
       expect(function () {
         SelectorFactory.selectorFor('values:foo:1-10');
+      }).to.throw('No selector registered with name "foo"');
+    });
+
+    it('should throw error the specified selector expression object is not valid', function () {
+      expect(function () {
+        SelectorFactory.selectorFor({});
+      }).to.throw('Not a valid selector expression object');
+    });
+
+    it('should throw error if no selectors are registered for the specified selector expression object', function () {
+      expect(function () {
+        SelectorFactory.selectorFor({
+          name: 'values',
+          selector: 'foo',
+          pattern: '1-10'
+        });
       }).to.throw('No selector registered with name "foo"');
     });
     

--- a/test/selectorFactory.test.js
+++ b/test/selectorFactory.test.js
@@ -35,14 +35,6 @@ describe('SelectorFactory', function () {
     }).to.throw('Expression "a:" is not a valid selector expression');
   });
 
-  it('should extract and return the name from the specified selector expression', function () {
-    expect(SelectorFactory.extractSelectorName('a:b:c')).to.be.eql('a');
-  });
-
-  it('should return expression as-is when extracting name if it is not a valid selector expression', function () {
-    expect(SelectorFactory.extractSelectorName('a')).to.be.eql('a');
-  });
-
   it('should throw error if attempt made to parse an invalid selector expression', function () {
     expect(function () {
       SelectorFactory.parse('a:');

--- a/test/simpleComponentDefinition.test.js
+++ b/test/simpleComponentDefinition.test.js
@@ -31,6 +31,12 @@ describe('SimpleComponentDefinition', function () {
 
   });
 
+  it('should have a type core.simple', function () {
+    var c = new SimpleComponentDefinition('myComponent', 'foo');
+
+    expect(c.type).to.be.equal('core.simple');
+  });
+
   it('should have the specified value', function () {
     var v = {};
     var c = new SimpleComponentDefinition('myComponent', v);


### PR DESCRIPTION
Tasks completed:

1. Add `type` attribute to all component definitions
2. Implement `SelectorFactory` to detect, parse, register and retrieve selectors
3. Modify `Registry` to filter register `ComponentDefinition` objects by specified selector
4. Modify `ComponentFactory` to implement single component assemby and selector based multi-component assembly
5. Implement default selectors `type`, `regexp` and `name`
6. Expose API to register new selectors via `Binder`
7. Register default selectors
8. Implement an example to demonstrate the use of selector based dependencies